### PR TITLE
fix: #33 Player volume can be decimal number

### DIFF
--- a/app/src/main/java/de/maniac103/squeezeclient/cometd/response/PlayerStatusResponse.kt
+++ b/app/src/main/java/de/maniac103/squeezeclient/cometd/response/PlayerStatusResponse.kt
@@ -66,7 +66,7 @@ data class PlayerStatusResponse(
     @SerialName("playlist repeat")
     val repeatState: PlayerStatus.RepeatState,
     @SerialName("mixer volume")
-    val currentVolume: Int,
+    val currentVolume: Double,
     @SerialName("digital_volume_control")
     @Serializable(with = BooleanAsIntSerializer::class)
     val digitalVolumeControl: Boolean,
@@ -116,8 +116,8 @@ data class PlayerStatusResponse(
             playerName,
             connected,
             powered,
-            abs(currentVolume),
-            currentVolume < 0,
+            abs(currentVolume.toInt()),
+            currentVolume < 0f,
             syncMaster,
             syncSlaves,
             eventTimestamp


### PR DESCRIPTION
See https://github.com/maniac103/squeezeclient/issues/33