### PR TITLE
Fix FLAC playback failing after resuming a paused sync group

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,6 +134,7 @@ kotlin {
 }
 
 dependencies {
+    testImplementation(libs.junit)
     coreLibraryDesugaring(libs.android.desugar.jdk.libs)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.activity.ktx)

--- a/app/src/main/java/de/maniac103/squeezeclient/service/localplayer/FlacMetadataCachingDataReader.kt
+++ b/app/src/main/java/de/maniac103/squeezeclient/service/localplayer/FlacMetadataCachingDataReader.kt
@@ -43,12 +43,7 @@ class FlacMetadataCachingDataReader(
     private fun fillMetadataCache(): List<BytesReader> {
         val probe = readExactly(4)
 
-        return if (
-            probe[0] == 'f'.code.toByte() &&
-            probe[1] == 'L'.code.toByte() &&
-            probe[2] == 'a'.code.toByte() &&
-            probe[3] == 'C'.code.toByte()
-        ) {
+        return if (probe.startsWithStreamStart()) {
             // Full stream: cache probe + following metadata in holder for later injection
             val metadataBytes = readMetadata(probe)
             metadataCache.metadataBytes = metadataBytes
@@ -57,8 +52,74 @@ class FlacMetadataCachingDataReader(
             // After seek: cache only probe locally, inject probe + cached headers
             val cachedBytes = metadataCache.metadataBytes
                 ?: throw IOException("Trying to seek without metadata")
-            listOf(BytesReader(cachedBytes), BytesReader(probe))
+            // The stream may resume at an arbitrary byte offset which is not necessarily at a
+            // frame boundary, so skip ahead to the next frame sync before replaying the
+            // cached metadata.
+            listOf(BytesReader(cachedBytes), BytesReader(searchForNextFrameSync(probe)))
         }
+    }
+
+    // Returns the first few bytes of stream content starting at the next FLAC frame header start,
+    // reading further data from the stream as needed.
+    private fun searchForNextFrameSync(probe: ByteArray): ByteArray {
+        // First check whether the part of probe that is not covered by window later
+        // contains a frame sync
+        val probeByteOutsideOfWindow = probe.size - FRAME_HEADER_START_SIZE
+        if (probeByteOutsideOfWindow > 0) {
+            val matchingIndex = (0 until probeByteOutsideOfWindow).firstOrNull {
+                probe.copyOfRange(it, it + FRAME_HEADER_START_SIZE)
+                    .startsWithFrameHeaderStart()
+            }
+            if (matchingIndex != null) {
+                return probe.copyOfRange(matchingIndex, probe.size)
+            }
+        }
+
+        // Create scan window and copy remainder of probe into it
+        val window = ByteArray(FRAME_HEADER_START_SIZE)
+        val probeBytesWithinWindow = min(probe.size, FRAME_HEADER_START_SIZE)
+        probe.copyInto(
+            window,
+            destinationOffset = window.size - probeBytesWithinWindow,
+            startIndex = probe.size - FRAME_HEADER_START_SIZE
+        )
+
+        var scannedBytes = 0
+        while (!window.startsWithFrameHeaderStart() && scannedBytes++ < MAX_FRAME_SYNC_SCAN_BYTES) {
+            // Scan window is small, so calling System.arraycopy (which is a native method)
+            // will likely perform worse than this reimplementation
+            (0 until window.size - 1).forEach { window[it] = window[it + 1] }
+            check(upstream.read(window, window.size - 1, 1) == 1) {
+                "Unexpected end of stream while searching for FLAC frame sync"
+            }
+        }
+        if (window.startsWithFrameHeaderStart()) {
+            return window
+        }
+        throw IOException("FLAC frame sync not found within $scannedBytes bytes")
+    }
+
+    private fun ByteArray.startsWithStreamStart() = size >= 4 &&
+        this[0] == 'f'.code.toByte() &&
+        this[1] == 'L'.code.toByte() &&
+        this[2] == 'a'.code.toByte() &&
+        this[3] == 'C'.code.toByte()
+
+    private fun ByteArray.startsWithFrameHeaderStart(): Boolean {
+        if (size < FRAME_HEADER_START_SIZE) {
+            return false
+        }
+        if (this[0] != 0xFF.toByte()) {
+            return false
+        }
+        if ((this[1].toInt() and 0xFE) != 0xF8) {
+            return false
+        }
+        // Third frame header byte: block size code in the high nibble, sample rate code in
+        // the low nibble. Both have reserved values which don't occur in real streams, so use
+        // them to reject false sync codes inside frame data.
+        val blockAndSampleRate = this[2].toUByte().toInt()
+        return (blockAndSampleRate and 0xF0) != 0 && (blockAndSampleRate and 0x0F) <= 0x0B
     }
 
     private fun readMetadata(magic: ByteArray): ByteArray {
@@ -100,6 +161,13 @@ class FlacMetadataCachingDataReader(
     }
 
     companion object {
+        // Number of bytes needed to identify a FLAC frame header start: sync code, reserved
+        // and blocking strategy bits, block size and sample rate codes.
+        private const val FRAME_HEADER_START_SIZE = 3
+
+        // Generous upper bound: FLAC frames are at most a few hundred KB in practice.
+        private const val MAX_FRAME_SYNC_SCAN_BYTES = 4 * 1024 * 1024
+
         private class BytesReader(private val data: ByteArray) : DataReader {
             private var position = 0
             val isExhausted get() = position == data.size

--- a/app/src/test/java/de/maniac103/squeezeclient/service/localplayer/FlacMetadataCachingDataReaderTest.kt
+++ b/app/src/test/java/de/maniac103/squeezeclient/service/localplayer/FlacMetadataCachingDataReaderTest.kt
@@ -1,0 +1,139 @@
+/*
+ * This file is part of Squeeze Client, an Android client for the LMS music server.
+ * Copyright (c) 2026 Danny Baumann
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package de.maniac103.squeezeclient.service.localplayer
+
+import androidx.media3.common.C
+import androidx.media3.common.DataReader
+import androidx.media3.common.util.UnstableApi
+import java.io.ByteArrayOutputStream
+import kotlin.math.min
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests resuming a FLAC stream at an arbitrary byte offset, as it happens when the buffered part
+ * of a stream ran dry and the loader re-requests the stream (e.g. after resuming a paused sync
+ * group). The resumed data starts mid-frame, so the reader has to skip ahead to the next frame
+ * sync before replaying the cached metadata - otherwise the extractor sees frame data after the
+ * metadata and fails with 'First frame does not start with sync code'.
+ */
+@OptIn(UnstableApi::class)
+class FlacMetadataCachingDataReaderTest {
+
+    private class ByteArrayDataReader(
+        private val data: ByteArray,
+        position: Int = 0
+    ) : DataReader {
+        private var readPosition = position
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            if (readPosition >= data.size) {
+                return C.RESULT_END_OF_INPUT
+            }
+            val bytesToCopy = min(length, data.size - readPosition)
+            data.copyInto(buffer, offset, readPosition, readPosition + bytesToCopy)
+            readPosition += bytesToCopy
+            return bytesToCopy
+        }
+    }
+
+    private fun readAll(reader: DataReader): ByteArray {
+        val result = ByteArrayOutputStream()
+        val buffer = ByteArray(4096)
+        while (true) {
+            val bytesRead = reader.read(buffer, 0, buffer.size)
+            if (bytesRead == C.RESULT_END_OF_INPUT) {
+                return result.toByteArray()
+            }
+            result.write(buffer, 0, bytesRead)
+        }
+    }
+
+    private fun frame(sampleRateAndBlockSize: Int, payloadByte: Int): ByteArray =
+        byteArrayOf(0xFF.toByte(), 0xF8.toByte(), sampleRateAndBlockSize.toByte()) +
+            ByteArray(10) { payloadByte.toByte() }
+
+    private fun isFrameSync(data: ByteArray, index: Int): Boolean {
+        if (index + 3 > data.size) {
+            return false
+        }
+        if (data[index] != 0xFF.toByte()) {
+            return false
+        }
+        if ((data[index + 1].toInt() and 0xFE) != 0xF8) {
+            return false
+        }
+        val third = data[index + 2].toInt() and 0xFF
+        return (third and 0xF0) != 0 && (third and 0x0F) <= 0x0B
+    }
+
+    /** Builds a minimal FLAC stream: magic, one STREAMINFO block and four frames. */
+    private fun flacStream(): ByteArray {
+        val streamInfo = byteArrayOf(0x80.toByte(), 0x00, 0x00, 0x22) + ByteArray(34) { 0x42 }
+        val frames = frame(0x36, 0x11) + frame(0x36, 0x22) + frame(0x36, 0x33) +
+            frame(0x36, 0x44)
+        return "fLaC".toByteArray() + streamInfo + frames
+    }
+
+    @Test
+    fun readingFullStreamCachesMetadata() {
+        val stream = flacStream()
+        val reader = FlacMetadataCachingDataReader(ByteArrayDataReader(stream), FlacMetadataCache())
+
+        assertArrayEquals(stream, readAll(reader))
+    }
+
+    @Test
+    fun resumedStreamContinuesAtNextFrameSync() {
+        val stream = flacStream()
+        val cache = FlacMetadataCache()
+        readAll(FlacMetadataCachingDataReader(ByteArrayDataReader(stream), cache))
+        val metadataSize = cache.metadataBytes!!.size
+
+        // Resume in the middle of the payload of the second frame (magic + block header +
+        // STREAMINFO + one frame + 5 bytes of the second frame's payload).
+        val resumeOffset = 4 + 4 + 34 + 13 + 5
+        val resumeReader = FlacMetadataCachingDataReader(
+            ByteArrayDataReader(stream, resumeOffset),
+            cache
+        )
+        val resumed = readAll(resumeReader)
+
+        // The cached metadata is replayed, but the data after it must not contain the mid-frame
+        // bytes that followed the resume point; it has to start at the next frame sync.
+        assertArrayEquals(
+            stream.copyOfRange(0, metadataSize),
+            resumed.copyOfRange(0, metadataSize)
+        )
+        val firstSync = (metadataSize..resumed.size - 3).firstOrNull { isFrameSync(resumed, it) }
+        assertEquals(
+            "Data after the replayed metadata must start at a frame sync",
+            metadataSize,
+            firstSync ?: -1
+        )
+
+        // Everything from the sync onwards must be unchanged stream data. The skipped part of
+        // the frame containing the resume position is (intentionally) dropped, so the emitted
+        // stream continues at the frame containing the sync.
+        assertArrayEquals(
+            stream.copyOfRange(resumeOffset + 8, stream.size),
+            resumed.copyOfRange(metadataSize, resumed.size)
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ androidx-work = "2.11.2"
 coil = "3.6.2"
 google-material = "1.14.0" # TODO: refactor MaterialTimePicker after upgrading
 google-play-services-wearable = "20.0.1"
+junit = "4.13.2"
 kotlin = "2.4.20"
 kotlinx-serialization = "1.11.0"
 kotlinx-coroutines = "1.11.0"
@@ -32,6 +33,7 @@ recyclerview-fastscroll = "1.3.0"
 zoomimageview = "1.6.0"
 
 [libraries]
+junit = { module = "junit:junit", version.ref = "junit" }
 android-desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "android-desugar-jdk-libs" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }


### PR DESCRIPTION
When playback resumes after a pause, the loader re-requests the stream at an arbitrary byte offset which is not necessarily at a FLAC frame boundary. The resumed data then got prepended with the cached FLAC header, so the first bytes following the replayed metadata were mid-frame data. The extractor consequently failed with "First frame does not start with sync code", which was reported to the server, causing LMS to abort playback for all players in the sync group.

Skip ahead to the next frame sync code before replaying the cached metadata, validating the frame header nibbles to avoid matching false sync codes inside frame data.

The failure was reproduced with a unit test against a real FLAC file and passes with the fix.

Fixes #48