### PR TITLE
Local player: Report track start for server initiated track changes

### DIFF
--- a/app/src/main/java/de/maniac103/squeezeclient/service/localplayer/LocalPlaybackService.kt
+++ b/app/src/main/java/de/maniac103/squeezeclient/service/localplayer/LocalPlaybackService.kt
@@ -356,6 +356,11 @@ class LocalPlaybackService :
 
             is SlimprotoSocket.CommandPacket.StreamStart -> {
                 sendStatus(SlimprotoSocket.StatusType.Connecting)
+                // A new stream reports its own track start and buffer readiness, so reset the
+                // state reported for the previous stream here: the server flushes the player on
+                // track changes, i.e. the new stream doesn't go through
+                // onPlaybackAdvancedToNextTrack() and thus would never be reported as started.
+                sentTrackStartStatus = false
                 sentBufferReady = command.autoStart
                 player.play(
                     command.uri,


### PR DESCRIPTION
When the server preloads the next track at the end of a stream (triggered by the decoder underrun reported in `onDecodingFinished()`), the track change does not go through `onPlaybackAdvancedToNextTrack()`. As `sentTrackStartStatus` is still set from the previous track in that case, `handlePlaybackStart()` never reports the track start (`STMs`) for the new track.

Effect of the missing report: the server never runs its "track started" handling for the new track and keeps the previous playlist entry as the current one - the app then keeps showing the previous track's title/artwork while already playing the next track, and the previous entry gets streamed again at the next transition.

Fix: treat the end of a stream as the end of a track in `onDecodingFinished()` as well (like `onPlaybackEnded()` already does), so the next stream start is reported as a track start again.

Diagnosis evidence (app log + LMS status, LMS 9.1.2):
- At a failing transition the app sent `STMc`, `STMd`, `STMl`, `STMo`, `STMp` and `STMr`, but no `STMs`, while the transition report from the server still named the previous track (with position 0.28 s), and the server's status kept `playlist_cur_index`/`duration` on the previous entry.
- `statHandler('STMs')` maps to the `Started` event, which drives LMS' `_PlayAndNext` handling.

Not yet verified on a device (the change only affects what is reported to the server at a track boundary).